### PR TITLE
Refactoring of cheap trip search

### DIFF
--- a/src/new_achitecture/modules/mainPage/presentation/components/MainPageComponent/MainPageComponent.jsx
+++ b/src/new_achitecture/modules/mainPage/presentation/components/MainPageComponent/MainPageComponent.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import {Container} from "@material-ui/core";
 import filtersClasses from "../../../../../modules/trip_search/lib/filterSearch/Filter/FilterComponent.module.css";
 
@@ -9,12 +9,12 @@ import CheapTripSearch from "../../../../trip_search/domain/entites/CheapTripSea
 import {Link} from "react-router-dom";
 
 export const MainPageComponent = () => {
-    const SloganMain = () => (
+    const SloganMain = useCallback(() => (
         <div className={css.MainSlogan}>
             Find most beneficial and unusual routes between cities, combining flight,
             train, bus, ferry and rideshare.
         </div>
-    );
+    ), []);
 
   return (
     <Container maxWidth="xl" className={css.tb_padding}>

--- a/src/new_achitecture/modules/trip_search/domain/entites/CheapTripSearch/CheapTripSearch.jsx
+++ b/src/new_achitecture/modules/trip_search/domain/entites/CheapTripSearch/CheapTripSearch.jsx
@@ -6,34 +6,19 @@ import {
   SORT_OPTIONS,
 } from '../utils/constants/sortConstants';
 import SearchForm from '../../../presentation/components/SearchForm/SearchForm';
+import SelectSortRoutes from '../../../presentation/components/SelectSortRoutes/SelectSortRoutes';
 
 function CheapTripSearch(props) {
   const { routes, filteredRoutes, PAGINATION_LIMIT, filterBy, selectSortBy } =
     useCheapTripSearch();
 
-  const handleSelectSortBy = (event) => {
-    selectSortBy(event.target.value);
-  };
   return (
     <>
       <SearchForm />
       <div>
         {routes && filteredRoutes ? (
           <>
-            <InputLabel id='demo-simple-select-label'>Sort</InputLabel>
-            <Select
-              labelId='demo-simple-select-label'
-              id='demo-simple-select'
-              value={filterBy}
-              label='Sort'
-              onChange={handleSelectSortBy}
-            >
-              {SORT_OPTIONS.map((item, index) => (
-                <MenuItem value={item} key={index}>
-                  {item}
-                </MenuItem>
-              ))}
-            </Select>
+            <SelectSortRoutes/>
           </>
         ) : null}
         {routes &&

--- a/src/new_achitecture/modules/trip_search/domain/entites/CheapTripSearch/CheapTripSearch.jsx
+++ b/src/new_achitecture/modules/trip_search/domain/entites/CheapTripSearch/CheapTripSearch.jsx
@@ -1,190 +1,22 @@
 import React from 'react';
-import { Autocomplete, createFilterOptions, TextField } from '@mui/material';
 import RouteCard from './RouteCard';
-import s from './cheaptrip.module.css';
-import classes from '../../../presentation/components/searchResult/SearchComponent.module.css';
-import DoubleArrowIcon from '@mui/icons-material/DoubleArrow';
-import { Button, InputLabel, Menu, MenuItem, Select } from '@material-ui/core';
-import i18n from '../utils/language/i18n';
+import { InputLabel, MenuItem, Select } from '@material-ui/core';
 import useCheapTripSearch from '../../../presentation/hooks/useCheapTripSearch';
 import {
   SORT_OPTIONS,
-  SORT_DIRECTION_OPTIONS,
 } from '../utils/constants/sortConstants';
-import ClearIcon from '@material-ui/icons/Clear';
+import SearchForm from '../../../presentation/components/SearchForm/SearchForm';
 
 function CheapTripSearch(props) {
-  const {
-    from,
-    selectFrom,
-    selectTo,
-    checkFromOption,
-    to,
-    checkToOption,
-    cleanForm,
-    submit,
-    routes,
-    filteredRoutes,
-    PAGINATION_LIMIT,
-    filterBy,
-    selectSortBy,
-    clearFromField,
-    clearToField,
-    inputValueFrom,
-    inputValueTo,
-    setInputFrom,
-    setInputTo,
-  } = useCheapTripSearch();
+  const { routes, filteredRoutes, PAGINATION_LIMIT, filterBy, selectSortBy } =
+    useCheapTripSearch();
 
-  const handleSelectFrom = (value) => {
-    selectFrom(value);
-  };
-  const handleSelectTo = (value) => {
-    selectTo(value);
-  };
-
-  const handleClearInput = (value) => {
-    value === 'from' ? clearFromField() : clearToField();
-  };
-
-  const handleCleanForm = () => {
-    cleanForm();
-  };
-  const handleSubmit = () => {
-    submit();
-  };
-
-  const handleFromInputValue = (value) => {
-    setInputFrom(value);
-  };
-  const handleToInputValue = (value) => {
-    setInputTo(value);
-  };
   const handleSelectSortBy = (event) => {
     selectSortBy(event.target.value);
   };
-
-  let inputFromStyle = {
-    color: 'rgb(118, 118, 118)',
-  };
-  let inputToStyle = {
-    color: 'rgb(118, 118, 118)',
-  };
-
   return (
-    <div>
-      <form action='' className={s.autocomplete}>
-        <Autocomplete
-          value={from || null}
-          onChange={(e, newValue) => {
-            handleSelectFrom(newValue ? newValue : '');
-          }}
-          onInputChange={(e, newValue) => {
-            handleFromInputValue(newValue);
-          }}
-          inputValue={inputValueFrom}
-          disablePortal
-          freeSolo
-          blurOnSelect
-          openOnFocus
-          options={checkFromOption}
-          sx={{ width: '100%' }}
-          onFocus={() => (inputFromStyle = { color: '#ff5722' })}
-          onBlur={() => (inputFromStyle = { color: 'rgb(118, 118, 118)' })}
-          disableClearable
-          ListboxProps={{ style: { maxHeight: 140 } }}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label='From'
-              variant='standard'
-              InputLabelProps={{
-                style: inputFromStyle,
-              }}
-              sx={{
-                '& .MuiInput-underline:before': {
-                  borderBottomColor: 'rgb(118, 118, 118)',
-                },
-                '& .MuiInput-underline:after': { borderBottomColor: '#ff5722' },
-              }}
-            />
-          )}
-          isOptionEqualToValue={(option, value) => option.label === value}
-        />
-        <ClearIcon
-          style={{ color: 'rgb(118, 118, 118)' }}
-          onClick={() => {
-            handleClearInput('from');
-          }}
-        />
-        <DoubleArrowIcon className={classes.media_icon} />
-        <Autocomplete
-          value={to || null}
-          onChange={(e, newValue) => {
-            handleSelectTo(newValue ? newValue : '');
-          }}
-          onInputChange={(e, newValue) => {
-            handleToInputValue(newValue);
-          }}
-          inputValue={inputValueTo}
-          disablePortal
-          freeSolo
-          blurOnSelect
-          openOnFocus
-          options={checkToOption}
-          sx={{ width: '100%' }}
-          onFocus={() => (inputToStyle = { color: '#ff5722' })}
-          onBlur={() => (inputToStyle = { color: 'rgb(118, 118, 118)' })}
-          disableClearable
-          ListboxProps={{ style: { maxHeight: 140 } }}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label='To'
-              variant='standard'
-              InputLabelProps={{
-                style: inputToStyle,
-              }}
-              sx={{
-                '& .MuiInput-underline:before': {
-                  borderBottomColor: 'rgb(118, 118, 118)',
-                },
-                '& .MuiInput-underline:after': { borderBottomColor: '#ff5722' },
-              }}
-            />
-          )}
-          isOptionEqualToValue={(option, value) => option.label === value}
-        />
-        <ClearIcon
-          style={{ color: 'rgb(118, 118, 118)' }}
-          onClick={() => {
-            handleClearInput('to');
-          }}
-        />
-      </form>
-      <div className={classes.filter_buttons}>
-        <Button
-          variant='contained'
-          color='secondary'
-          onClick={handleCleanForm}
-          type='reset'
-          disableElevation // disable shade
-          style={{ textTransform: 'none' }}
-        >
-          {i18n.t('Clear form')}
-        </Button>
-        <Button
-          variant='contained'
-          color='primary'
-          onClick={handleSubmit}
-          style={{ marginLeft: '10px', textTransform: 'none', color: '#fff' }}
-          type='button'
-          disableElevation
-          disabled={to === '' || from === ''}
-        >
-          {i18n.t("Let's go")}
-        </Button>
-      </div>
+    <>
+      <SearchForm />
       <div>
         {routes && filteredRoutes ? (
           <>
@@ -206,16 +38,14 @@ function CheapTripSearch(props) {
         ) : null}
         {routes &&
           filteredRoutes &&
-          filteredRoutes
-            .slice(0, PAGINATION_LIMIT)
-            .map((route, index) => {
-              return <RouteCard route={route} key={route + index} />;
-            })}
+          filteredRoutes.slice(0, PAGINATION_LIMIT).map((route, index) => {
+            return <RouteCard route={route} key={route + index} />;
+          })}
         {routes && filteredRoutes && filteredRoutes.length === 0 && (
           <p>No such routes</p>
         )}
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/new_achitecture/modules/trip_search/domain/entites/CheapTripSearch/CheapTripSearch.jsx
+++ b/src/new_achitecture/modules/trip_search/domain/entites/CheapTripSearch/CheapTripSearch.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
 import RouteCard from './RouteCard';
-import { InputLabel, MenuItem, Select } from '@material-ui/core';
 import useCheapTripSearch from '../../../presentation/hooks/useCheapTripSearch';
-import {
-  SORT_OPTIONS,
-} from '../utils/constants/sortConstants';
 import SearchForm from '../../../presentation/components/SearchForm/SearchForm';
 import SelectSortRoutes from '../../../presentation/components/SelectSortRoutes/SelectSortRoutes';
 
 function CheapTripSearch(props) {
-  const { routes, filteredRoutes, PAGINATION_LIMIT, filterBy, selectSortBy } =
-    useCheapTripSearch();
+  const { routes, filteredRoutes, PAGINATION_LIMIT } = useCheapTripSearch();
 
   return (
     <>
@@ -18,7 +13,7 @@ function CheapTripSearch(props) {
       <div>
         {routes && filteredRoutes ? (
           <>
-            <SelectSortRoutes/>
+            <SelectSortRoutes />
           </>
         ) : null}
         {routes &&

--- a/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/AutocompleteEl/AutocompleteEl.jsx
+++ b/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/AutocompleteEl/AutocompleteEl.jsx
@@ -1,0 +1,60 @@
+import { Autocomplete } from '@mui/material';
+import React from 'react';
+import {
+  inputFromStyle,
+  inputToStyle,
+  basicColor,
+  colorOnFocus,
+  colorOnBlur,
+  sxForTextField,
+  sxForAutocomplete,
+} from './../searchFormStyles';
+import { TextField } from '@material-ui/core';
+
+const AutocompleteEl = ({
+  value,
+  handleChange,
+  handleInputChange,
+  inputValue,
+  options,
+  textFieldLabel,
+  inputStyle,
+}) => {
+  console.log(value);
+  return (
+    <Autocomplete
+      value={value || null}
+      onChange={(e, newValue) => {
+        handleChange(newValue ? newValue : '');
+      }}
+      onInputChange={(e, newValue) => {
+        handleInputChange(newValue);
+      }}
+      inputValue={inputValue}
+      disablePortal
+      freeSolo
+      blurOnSelect
+      openOnFocus
+      options={options}
+      sx={sxForAutocomplete}
+      onFocus={() => (inputStyle = { colorOnFocus })}
+      onBlur={() => (inputStyle = colorOnBlur)}
+      disableClearable
+      ListboxProps={{ style: { maxHeight: 140 } }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={textFieldLabel}
+          variant='standard'
+          InputLabelProps={{
+            style: inputStyle,
+          }}
+          sx={sxForTextField}
+        />
+      )}
+      isOptionEqualToValue={(option, value) => option.label === value}
+    />
+  );
+};
+
+export default AutocompleteEl;

--- a/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/AutocompleteEl/AutocompleteEl.jsx
+++ b/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/AutocompleteEl/AutocompleteEl.jsx
@@ -1,12 +1,11 @@
-import { Autocomplete } from '@mui/material';
 import React from 'react';
+import { Autocomplete, TextField } from '@mui/material';
 import {
   colorOnFocus,
   colorOnBlur,
   sxForTextField,
   sxForAutocomplete,
 } from './../searchFormStyles';
-import { TextField } from '@material-ui/core';
 
 const AutocompleteEl = ({
   value,
@@ -34,7 +33,7 @@ const AutocompleteEl = ({
       openOnFocus
       options={options}
       sx={sxForAutocomplete}
-      onFocus={() => (inputStyle = { colorOnFocus })}
+      onFocus={() => (inputStyle = colorOnFocus)}
       onBlur={() => (inputStyle = colorOnBlur)}
       disableClearable
       ListboxProps={{ style: { maxHeight: 140 } }}

--- a/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/AutocompleteEl/AutocompleteEl.jsx
+++ b/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/AutocompleteEl/AutocompleteEl.jsx
@@ -1,9 +1,6 @@
 import { Autocomplete } from '@mui/material';
 import React from 'react';
 import {
-  inputFromStyle,
-  inputToStyle,
-  basicColor,
   colorOnFocus,
   colorOnBlur,
   sxForTextField,

--- a/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/SearchForm.jsx
+++ b/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/SearchForm.jsx
@@ -1,6 +1,5 @@
-import React, { useEffect } from 'react';
-import { Autocomplete, createFilterOptions, TextField } from '@mui/material';
-import { Button, Menu } from '@material-ui/core';
+import React from 'react';
+import { Button } from '@material-ui/core';
 import useCheapTripSearch from '../../hooks/useCheapTripSearch';
 import s from './../../../domain/entites/CheapTripSearch/cheaptrip.module.css';
 import classes from './../../../presentation/components/searchResult/SearchComponent.module.css';

--- a/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/SearchForm.jsx
+++ b/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/SearchForm.jsx
@@ -1,0 +1,181 @@
+import React, { useEffect } from 'react'
+import { Autocomplete, createFilterOptions, TextField } from '@mui/material';
+import { Button, Menu } from '@material-ui/core';
+import useCheapTripSearch from '../../hooks/useCheapTripSearch';
+import s from './../../../domain/entites/CheapTripSearch/cheaptrip.module.css';
+import classes from './../../../presentation/components/searchResult/SearchComponent.module.css'
+import i18n from './../../../domain/entites/utils/language/i18n';
+import ClearIcon from '@material-ui/icons/Clear';
+import DoubleArrowIcon from '@mui/icons-material/DoubleArrow';
+
+const SearchForm = () => {
+  const {
+    from,
+    selectFrom,
+    selectTo,
+    checkFromOption,
+    to,
+    checkToOption,
+    cleanForm,
+    submit,
+    clearFromField,
+    clearToField,
+    inputValueFrom,
+    inputValueTo,
+    setInputFrom,
+    setInputTo,
+  } = useCheapTripSearch();
+
+  const handleSelectFrom = (value) => {
+    selectFrom(value);
+  };
+  const handleSelectTo = (value) => {
+    selectTo(value);
+  };
+
+  const handleClearInput = (value) => {
+    value === 'from' ? clearFromField() : clearToField();
+  };
+
+  const handleCleanForm = () => {
+    cleanForm();
+  };
+  const handleSubmit = () => {
+    submit();
+  };
+
+  const handleFromInputValue = (value) => {
+    setInputFrom(value);
+  };
+  const handleToInputValue = (value) => {
+    setInputTo(value);
+  };
+
+  let inputFromStyle = {
+    color: 'rgb(118, 118, 118)',
+  };
+  let inputToStyle = {
+    color: 'rgb(118, 118, 118)',
+  };
+
+  return (
+    <>
+          <form action='' className={s.autocomplete}>
+        <Autocomplete
+          value={from || null}
+          onChange={(e, newValue) => {
+            handleSelectFrom(newValue ? newValue : '');
+          }}
+          onInputChange={(e, newValue) => {
+            handleFromInputValue(newValue);
+          }}
+          inputValue={inputValueFrom}
+          disablePortal
+          freeSolo
+          blurOnSelect
+          openOnFocus
+          options={checkFromOption}
+          sx={{ width: '100%' }}
+          onFocus={() => (inputFromStyle = { color: '#ff5722' })}
+          onBlur={() => (inputFromStyle = { color: 'rgb(118, 118, 118)' })}
+          disableClearable
+          ListboxProps={{ style: { maxHeight: 140 } }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label='From'
+              variant='standard'
+              InputLabelProps={{
+                style: inputFromStyle,
+              }}
+              sx={{
+                '& .MuiInput-underline:before': {
+                  borderBottomColor: 'rgb(118, 118, 118)',
+                },
+                '& .MuiInput-underline:after': { borderBottomColor: '#ff5722' },
+              }}
+            />
+          )}
+          isOptionEqualToValue={(option, value) => option.label === value}
+        />
+        <ClearIcon
+          style={{ color: 'rgb(118, 118, 118)' }}
+          onClick={() => {
+            handleClearInput('from');
+          }}
+        />
+        <DoubleArrowIcon className={classes.media_icon} />
+        <Autocomplete
+          value={to || null}
+          onChange={(e, newValue) => {
+            handleSelectTo(newValue ? newValue : '');
+          }}
+          onInputChange={(e, newValue) => {
+            handleToInputValue(newValue);
+          }}
+          inputValue={inputValueTo}
+          disablePortal
+          freeSolo
+          blurOnSelect
+          openOnFocus
+          options={checkToOption}
+          sx={{ width: '100%' }}
+          onFocus={() => (inputToStyle = { color: '#ff5722' })}
+          onBlur={() => (inputToStyle = { color: 'rgb(118, 118, 118)' })}
+          disableClearable
+          ListboxProps={{ style: { maxHeight: 140 } }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label='To'
+              variant='standard'
+              InputLabelProps={{
+                style: inputToStyle,
+              }}
+              sx={{
+                '& .MuiInput-underline:before': {
+                  borderBottomColor: 'rgb(118, 118, 118)',
+                },
+                '& .MuiInput-underline:after': { borderBottomColor: '#ff5722' },
+              }}
+            />
+          )}
+          isOptionEqualToValue={(option, value) => option.label === value}
+        />
+        <ClearIcon
+          style={{ color: 'rgb(118, 118, 118)' }}
+          onClick={() => {
+            handleClearInput('to');
+          }}
+        />
+      </form>
+      <div className={classes.filter_buttons}>
+        <Button
+          variant='contained'
+          color='secondary'
+          onClick={handleCleanForm}
+          type='reset'
+          disableElevation // disable shade
+          style={{ textTransform: 'none' }}
+        >
+          {/* {i18n.t('Clear form')} */}
+          Clear form
+        </Button>
+        <Button
+          variant='contained'
+          color='primary'
+          onClick={handleSubmit}
+          style={{ marginLeft: '10px', textTransform: 'none', color: '#fff' }}
+          type='button'
+          disableElevation
+          disabled={to === '' || from === ''}
+        >
+          {/* {i18n.t("Let's go")} */}
+          Let's go
+        </Button>
+      </div>
+    </>
+  )
+}
+
+export default SearchForm

--- a/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/SearchForm.jsx
+++ b/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/SearchForm.jsx
@@ -1,12 +1,14 @@
-import React, { useEffect } from 'react'
+import React, { useEffect } from 'react';
 import { Autocomplete, createFilterOptions, TextField } from '@mui/material';
 import { Button, Menu } from '@material-ui/core';
 import useCheapTripSearch from '../../hooks/useCheapTripSearch';
 import s from './../../../domain/entites/CheapTripSearch/cheaptrip.module.css';
-import classes from './../../../presentation/components/searchResult/SearchComponent.module.css'
+import classes from './../../../presentation/components/searchResult/SearchComponent.module.css';
 import i18n from './../../../domain/entites/utils/language/i18n';
 import ClearIcon from '@material-ui/icons/Clear';
 import DoubleArrowIcon from '@mui/icons-material/DoubleArrow';
+import AutocompleteEl from './AutocompleteEl/AutocompleteEl';
+import { inputFromStyle, inputToStyle, basicColor } from './searchFormStyles';
 
 const SearchForm = () => {
   const {
@@ -51,99 +53,36 @@ const SearchForm = () => {
     setInputTo(value);
   };
 
-  let inputFromStyle = {
-    color: 'rgb(118, 118, 118)',
-  };
-  let inputToStyle = {
-    color: 'rgb(118, 118, 118)',
-  };
-
   return (
     <>
-          <form action='' className={s.autocomplete}>
-        <Autocomplete
+      <form action='' className={s.autocomplete}>
+        <AutocompleteEl
           value={from || null}
-          onChange={(e, newValue) => {
-            handleSelectFrom(newValue ? newValue : '');
-          }}
-          onInputChange={(e, newValue) => {
-            handleFromInputValue(newValue);
-          }}
+          handleChange={handleSelectFrom}
+          handleInputChange={handleFromInputValue}
           inputValue={inputValueFrom}
-          disablePortal
-          freeSolo
-          blurOnSelect
-          openOnFocus
           options={checkFromOption}
-          sx={{ width: '100%' }}
-          onFocus={() => (inputFromStyle = { color: '#ff5722' })}
-          onBlur={() => (inputFromStyle = { color: 'rgb(118, 118, 118)' })}
-          disableClearable
-          ListboxProps={{ style: { maxHeight: 140 } }}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label='From'
-              variant='standard'
-              InputLabelProps={{
-                style: inputFromStyle,
-              }}
-              sx={{
-                '& .MuiInput-underline:before': {
-                  borderBottomColor: 'rgb(118, 118, 118)',
-                },
-                '& .MuiInput-underline:after': { borderBottomColor: '#ff5722' },
-              }}
-            />
-          )}
-          isOptionEqualToValue={(option, value) => option.label === value}
+          textFieldLabel={'From'}
+          inputStyle={inputFromStyle}
         />
         <ClearIcon
-          style={{ color: 'rgb(118, 118, 118)' }}
+          style={basicColor}
           onClick={() => {
             handleClearInput('from');
           }}
         />
         <DoubleArrowIcon className={classes.media_icon} />
-        <Autocomplete
+        <AutocompleteEl
           value={to || null}
-          onChange={(e, newValue) => {
-            handleSelectTo(newValue ? newValue : '');
-          }}
-          onInputChange={(e, newValue) => {
-            handleToInputValue(newValue);
-          }}
+          handleChange={handleSelectTo}
+          handleInputChange={handleToInputValue}
           inputValue={inputValueTo}
-          disablePortal
-          freeSolo
-          blurOnSelect
-          openOnFocus
           options={checkToOption}
-          sx={{ width: '100%' }}
-          onFocus={() => (inputToStyle = { color: '#ff5722' })}
-          onBlur={() => (inputToStyle = { color: 'rgb(118, 118, 118)' })}
-          disableClearable
-          ListboxProps={{ style: { maxHeight: 140 } }}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label='To'
-              variant='standard'
-              InputLabelProps={{
-                style: inputToStyle,
-              }}
-              sx={{
-                '& .MuiInput-underline:before': {
-                  borderBottomColor: 'rgb(118, 118, 118)',
-                },
-                '& .MuiInput-underline:after': { borderBottomColor: '#ff5722' },
-              }}
-            />
-          )}
-          isOptionEqualToValue={(option, value) => option.label === value}
+          textFieldLabel={'To'}
+          inputStyle={inputToStyle}
         />
         <ClearIcon
-          style={{ color: 'rgb(118, 118, 118)' }}
+          style={basicColor}
           onClick={() => {
             handleClearInput('to');
           }}
@@ -158,8 +97,7 @@ const SearchForm = () => {
           disableElevation // disable shade
           style={{ textTransform: 'none' }}
         >
-          {/* {i18n.t('Clear form')} */}
-          Clear form
+          {i18n.t('Clear form')}
         </Button>
         <Button
           variant='contained'
@@ -170,12 +108,11 @@ const SearchForm = () => {
           disableElevation
           disabled={to === '' || from === ''}
         >
-          {/* {i18n.t("Let's go")} */}
-          Let's go
+          {i18n.t("Let's go")}
         </Button>
       </div>
     </>
-  )
-}
+  );
+};
 
-export default SearchForm
+export default SearchForm;

--- a/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/searchFormStyles.js
+++ b/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/searchFormStyles.js
@@ -18,4 +18,4 @@ export let sxForTextField = {
   '& .MuiInput-underline:after': { borderBottomColor: '#ff5722' },
 };
 
-export let sxForAutocomplete = { width: '100%'};
+export let sxForAutocomplete = { width: '100%' };

--- a/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/searchFormStyles.js
+++ b/src/new_achitecture/modules/trip_search/presentation/components/SearchForm/searchFormStyles.js
@@ -1,0 +1,21 @@
+export let inputFromStyle = {
+  color: 'rgb(118, 118, 118)',
+};
+export let inputToStyle = {
+  color: 'rgb(118, 118, 118)',
+};
+
+export let basicColor = { color: 'rgb(118, 118, 118)' };
+
+export let colorOnFocus = { color: '#ff5722' };
+
+export let colorOnBlur = { color: 'rgb(118, 118, 118)' };
+
+export let sxForTextField = {
+  '& .MuiInput-underline:before': {
+    borderBottomColor: 'rgb(118, 118, 118)',
+  },
+  '& .MuiInput-underline:after': { borderBottomColor: '#ff5722' },
+};
+
+export let sxForAutocomplete = { width: '100%'};

--- a/src/new_achitecture/modules/trip_search/presentation/components/SelectSortRoutes/SelectSortRoutes.jsx
+++ b/src/new_achitecture/modules/trip_search/presentation/components/SelectSortRoutes/SelectSortRoutes.jsx
@@ -1,0 +1,42 @@
+import { InputLabel, MenuItem, Select } from '@material-ui/core'
+import React from 'react'
+import { SORT_OPTIONS } from '../../../domain/entites/utils/constants/sortConstants'
+import { useDispatch, useSelector } from 'react-redux';
+import { setFilter } from './../../redux/reducers/cheapTripSearch/cheapTripSearchSlice';
+
+
+const SelectSortRoutes = () => {
+
+  const { filterBy } = useSelector((state) => {
+    return state.cheapTripSearch;
+  });
+  const dispatch = useDispatch();
+
+  const selectSortBy = (value) => {
+    dispatch(setFilter(value));
+  };
+  
+  const handleSelectSortBy = (event) => {
+    selectSortBy(event.target.value);
+  };
+  return (
+    <>
+            <InputLabel id='demo-simple-select-label'>Sort</InputLabel>
+            <Select
+              labelId='demo-simple-select-label'
+              id='demo-simple-select'
+              value={filterBy}
+              label='Sort'
+              onChange={handleSelectSortBy}
+            >
+              {SORT_OPTIONS.map((item, index) => (
+                <MenuItem value={item} key={index}>
+                  {item}
+                </MenuItem>
+              ))}
+            </Select>
+          </>
+  )
+}
+
+export default SelectSortRoutes

--- a/src/new_achitecture/modules/trip_search/presentation/hooks/useCheapTripSearch.jsx
+++ b/src/new_achitecture/modules/trip_search/presentation/hooks/useCheapTripSearch.jsx
@@ -197,9 +197,7 @@ const useCheapTripSearch = () => {
     );
   };
 
-  const selectSortBy = (value) => {
-    dispatch(setFilter(value));
-  };
+
   const setInputFrom = (value) => {
     setInputValueFrom(value);
   };
@@ -221,7 +219,6 @@ const useCheapTripSearch = () => {
     PAGINATION_LIMIT,
     sortByDuration,
     sortByPrice,
-    selectSortBy,
     filterBy,
     clearFromField,
     clearToField,

--- a/src/new_achitecture/modules/trip_search/presentation/hooks/useCheapTripSearch.jsx
+++ b/src/new_achitecture/modules/trip_search/presentation/hooks/useCheapTripSearch.jsx
@@ -6,7 +6,7 @@ import locations from '../../data/jsons/cheapTripData/locations.json';
 import { asyncAutocomplete } from '../../domain/entites/CheapTripSearch/asyncAutocomplete';
 import { SORT_OPTIONS } from '../../domain/entites/utils/constants/sortConstants';
 import { useDispatch, useSelector } from 'react-redux';
-import {setFilter} from "../redux/reducers/cheapTripSearch/cheapTripSearchSlice";
+import { setFilter, setFilteredRoutes } from '../redux/reducers/cheapTripSearch/cheapTripSearchSlice';
 
 const useCheapTripSearch = () => {
   const [from, setFrom] = useState('');
@@ -17,37 +17,15 @@ const useCheapTripSearch = () => {
   const [asyncToOptions, setAsyncToOptions] = useState([]);
   const [geoLocation, setGeoLocation] = useState({ latitude: 0, longitude: 0 });
   const [selectedRoutesKeys, setSelectedRoutesKeys] = useState(null);
-  const [filteredRoutes, setFilteredRoutes] = useState(null);
   const [inputValueFrom, setInputValueFrom] = useState('');
   const [inputValueTo, setInputValueTo] = useState('');
-  const { filterBy } = useSelector((state) => {
+  const { filterBy, filteredRoutes } = useSelector((state) => {
     return state.cheapTripSearch;
   });
   const dispatch = useDispatch();
 
   const PAGINATION_LIMIT = 10;
   const routes = { ...flying_routes, ...fixed_routes, ...common_routes };
-
-  useEffect(() => {
-    if (selectedRoutesKeys) {
-      let sortedRoutes;
-      switch (filterBy) {
-        case SORT_OPTIONS[0]:
-          sortedRoutes = sortByPrice([...selectedRoutesKeys]);
-          break;
-        case SORT_OPTIONS[1]:
-          sortedRoutes = sortByDuration([...selectedRoutesKeys]);
-          break;
-        case SORT_OPTIONS[2]:
-          sortedRoutes = sortByLayovers([...selectedRoutesKeys]);
-          console.log(`in sorting by layovers`, sortedRoutes);
-          break;
-        default:
-          return;
-      }
-      setFilteredRoutes(sortedRoutes);
-    }
-  }, [filterBy, selectedRoutesKeys]);
 
   // Here the routes with a common key will merge into an array like: 89091: [{...}, {...}]
   const routesForRender = {};
@@ -152,16 +130,37 @@ const useCheapTripSearch = () => {
     dispatch(setFilter(SORT_OPTIONS[0]));
   };
 
-  const startAsyncAutocomplete = (e, setState, options) => {
-    // get geolocation
-    navigator.geolocation.getCurrentPosition(function (position) {
-      setGeoLocation({
-        latitude: position.coords.latitude,
-        longitude: position.coords.longitude,
-      });
-    });
-    asyncAutocomplete(e, setState, options, geoLocation);
-  };
+  useEffect(() => {
+    if (selectedRoutesKeys) {
+      let sortedRoutes = [];
+      switch (filterBy) {
+        case SORT_OPTIONS[0]:
+          sortedRoutes = sortByPrice([...selectedRoutesKeys]);
+          break;
+        case SORT_OPTIONS[1]:
+          sortedRoutes = sortByDuration([...selectedRoutesKeys]);
+          break;
+        case SORT_OPTIONS[2]:
+          sortedRoutes = sortByLayovers([...selectedRoutesKeys]);
+          break;
+        default:
+          return;
+      }
+
+      dispatch(setFilteredRoutes(sortedRoutes));
+    }
+  }, [filterBy, selectedRoutesKeys]);
+
+  // const startAsyncAutocomplete = (e, setState, options) => {
+  //   // get geolocation
+  //   navigator.geolocation.getCurrentPosition(function (position) {
+  //     setGeoLocation({
+  //       latitude: position.coords.latitude,
+  //       longitude: position.coords.longitude,
+  //     });
+  //   });
+  //   asyncAutocomplete(e, setState, options, geoLocation);
+  // };
 
   const checkFromOption =
     asyncFromOptions.length !== 0 ? asyncFromOptions : fromOptions;
@@ -193,12 +192,12 @@ const useCheapTripSearch = () => {
   const sortByLayovers = (arr) => {
     const allRoutes = [].concat(...arr.map((key) => routesForRender[key]));
     return allRoutes.sort(
-      (route1, route2) => route1.direct_routes.length - route2.direct_routes.length
+      (route1, route2) =>
+        route1.direct_routes.length - route2.direct_routes.length
     );
   };
 
   const selectSortBy = (value) => {
-    console.log(value);
     dispatch(setFilter(value));
   };
   const setInputFrom = (value) => {

--- a/src/new_achitecture/modules/trip_search/presentation/redux/reducers/cheapTripSearch/cheapTripSearchSlice.js
+++ b/src/new_achitecture/modules/trip_search/presentation/redux/reducers/cheapTripSearch/cheapTripSearchSlice.js
@@ -3,15 +3,18 @@ import { SORT_OPTIONS } from '../../../../domain/entites/utils/constants/sortCon
 
 const cheapTripSearchSlice = createSlice({
   name: 'cheapTripSearch',
-  initialState: { filterBy: SORT_OPTIONS[0] },
+  initialState: { filterBy: SORT_OPTIONS[0], filteredRoutes: null },
   reducers: {
     setFilter(state, { payload }) {
       state.filterBy = payload;
+    },
+    setFilteredRoutes(state, { payload }) {
+      state.filteredRoutes = payload;
     },
   },
 });
 const { actions, reducer } = cheapTripSearchSlice;
 
-export const { setFilter } = actions;
+export const { setFilter, setFilteredRoutes } = actions;
 
 export default reducer;


### PR DESCRIPTION
The search box from cheap trip search was moved to its own component
Autocomplete was moved to its own component
In cheapTripSearchSlice added a new field 'filteredRoutes' for the re-render of the main component.
Styles for CheapTripSearch were moved to their own .js file.